### PR TITLE
Add basic Node.js food tracker example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# pku
+# PKU Food Tracker
+
+This is a minimal Node.js/Express web application for demonstrating a phenylalanine tracking tool. It serves a basic UI that fetches a list of sample foods with their phenylalanine content.
+
+## Requirements
+- Node.js 20+
+
+## Install
+```bash
+npm install
+```
+
+## Run
+```bash
+npm start
+```
+The application runs on [http://localhost:3000](http://localhost:3000).
+
+## File Structure
+- `src/server.js` – Express server with a sample API endpoint.
+- `src/public/` – Static front‑end files.
+
+This project is intended as a starting point for building a more complete PKU management application.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "pku",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0"
+  }
+}

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -1,0 +1,11 @@
+fetch('/api/foods')
+  .then(res => res.json())
+  .then(data => {
+    const list = document.getElementById('foods');
+    data.forEach(item => {
+      const li = document.createElement('li');
+      li.textContent = `${item.name} - ${item.phenylalanineMg} mg Phe`;
+      list.appendChild(li);
+    });
+  })
+  .catch(err => console.error('Error fetching foods:', err));

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>PKU Food Tracker</title>
+  <script defer src="app.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    #foods { margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <h1>PKU Food Tracker</h1>
+  <p>This is a simple application to view sample phenylalanine amounts in foods.</p>
+  <ul id="foods"></ul>
+</body>
+</html>

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const port = process.env.PORT || 3000;
+
+// Sample food data
+const foods = [
+  { id: 1, name: 'Apple', phenylalanineMg: 2 },
+  { id: 2, name: 'Banana', phenylalanineMg: 8 },
+  { id: 3, name: 'Chicken Breast (100g)', phenylalanineMg: 320 },
+];
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/api/foods', (req, res) => {
+  res.json(foods);
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- scaffold an Express server with a sample `/api/foods` endpoint
- add minimal static front-end to display foods
- document how to install and run the app
- ignore Node packages in git

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(server runs and prints listening message)*

------
https://chatgpt.com/codex/tasks/task_e_68448c15b8f083228da384349f4cabbe