### PR TITLE
Add basic login page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The application runs on [http://localhost:3000](http://localhost:3000).
 The app includes a simple login form available at `/login` with hard-coded
 credentials (`user`/`pass`) for demonstration purposes.
 
+## Add Foods
+Visit `/add` to enter a new food and its phenylalanine amount. Newly added
+items appear on the main page.
+
 ## File Structure
 - `src/server.js` – Express server with a sample API endpoint.
 - `src/public/` – Static front‑end files.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# pku
+# PKU Food Tracker
+
+This is a minimal Node.js/Express web application for demonstrating a phenylalanine tracking tool. It serves a basic UI that fetches a list of sample foods with their phenylalanine content.
+
+## Requirements
+- Node.js 20+
+
+## Install
+```bash
+npm install
+```
+
+## Run
+```bash
+npm start
+```
+The application runs on [http://localhost:3000](http://localhost:3000).
+
+## Authentication
+The app includes a simple login form available at `/login` with hard-coded
+credentials (`user`/`pass`) for demonstration purposes.
+
+## File Structure
+- `src/server.js` – Express server with a sample API endpoint.
+- `src/public/` – Static front‑end files.
+
+This project is intended as a starting point for building a more complete PKU management application.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "pku",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0"
+  }
+}

--- a/src/public/add.html
+++ b/src/public/add.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Add Food</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    form { max-width: 300px; }
+    label { display: block; margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Add Food</h1>
+  <form method="POST" action="/add">
+    <label>
+      Food name
+      <input type="text" name="name" required />
+    </label>
+    <label>
+      Phenylalanine (mg)
+      <input type="number" name="phenylalanineMg" required />
+    </label>
+    <button type="submit">Save</button>
+  </form>
+</body>
+</html>

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -1,0 +1,11 @@
+fetch('/api/foods')
+  .then(res => res.json())
+  .then(data => {
+    const list = document.getElementById('foods');
+    data.forEach(item => {
+      const li = document.createElement('li');
+      li.textContent = `${item.name} - ${item.phenylalanineMg} mg Phe`;
+      list.appendChild(li);
+    });
+  })
+  .catch(err => console.error('Error fetching foods:', err));

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>PKU Food Tracker</title>
+  <script defer src="app.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    #foods { margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <h1>PKU Food Tracker</h1>
+  <p>This is a simple application to view sample phenylalanine amounts in foods.</p>
+  <p><a href="/login">Log In</a></p>
+  <ul id="foods"></ul>
+</body>
+</html>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -12,7 +12,7 @@
 <body>
   <h1>PKU Food Tracker</h1>
   <p>This is a simple application to view sample phenylalanine amounts in foods.</p>
-  <p><a href="/login">Log In</a></p>
+  <p><a href="/login">Log In</a> | <a href="/add">Add Food</a></p>
   <ul id="foods"></ul>
 </body>
 </html>

--- a/src/public/login.html
+++ b/src/public/login.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Login</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    form { max-width: 300px; }
+    label { display: block; margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Login</h1>
+  <form method="POST" action="/login">
+    <label>
+      Username
+      <input type="text" name="username" required />
+    </label>
+    <label>
+      Password
+      <input type="password" name="password" required />
+    </label>
+    <button type="submit">Log In</button>
+  </form>
+</body>
+</html>

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const port = process.env.PORT || 3000;
+
+// Simple user credentials
+const user = { username: 'user', password: 'pass' };
+
+// Sample food data
+const foods = [
+  { id: 1, name: 'Apple', phenylalanineMg: 2 },
+  { id: 2, name: 'Banana', phenylalanineMg: 8 },
+  { id: 3, name: 'Chicken Breast (100g)', phenylalanineMg: 320 },
+];
+
+app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.urlencoded({ extended: true }));
+
+app.get('/api/foods', (req, res) => {
+  res.json(foods);
+});
+
+app.get('/login', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'login.html'));
+});
+
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  if (username === user.username && password === user.password) {
+    res.send('Login successful');
+  } else {
+    res.status(401).send('Invalid credentials');
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/src/server.js
+++ b/src/server.js
@@ -20,6 +20,25 @@ app.get('/api/foods', (req, res) => {
   res.json(foods);
 });
 
+app.get('/add', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'add.html'));
+});
+
+app.post('/add', (req, res) => {
+  const { name, phenylalanineMg } = req.body;
+  if (name && phenylalanineMg) {
+    const newFood = {
+      id: foods.length + 1,
+      name,
+      phenylalanineMg: Number(phenylalanineMg),
+    };
+    foods.push(newFood);
+    res.redirect('/');
+  } else {
+    res.status(400).send('Invalid data');
+  }
+});
+
 app.get('/login', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'login.html'));
 });


### PR DESCRIPTION
## Summary
- add a `/login` page with a simple form
- handle login in `server.js` with a hardcoded user
- link to the login page from the main index
- document the login route in the README

## Testing
- `npm test` *(fails: no test specified)*
- `npm start` *(server runs and logs "Server listening on port 3000")*

------
https://chatgpt.com/codex/tasks/task_e_68448c15b8f083228da384349f4cabbe